### PR TITLE
Updated to latest widget versions

### DIFF
--- a/component.json
+++ b/component.json
@@ -17,10 +17,10 @@
     "gjohnson/uuid": "ca90d4daf2a02a667e33e8a1938ad251cfcc8979",
     "goinstant/user-list":"v1.1.0",
     "goinstant/user-colors":"v1.0.1",
-    "goinstant/scroll-indicator":"v1.2.0",
-    "goinstant/click-indicator":"v1.1.1",
-    "goinstant/form":"v1.1.0",
-    "goinstant/chat":"v1.0.0"
+    "goinstant/scroll-indicator":"v1.2.1",
+    "goinstant/click-indicator":"v1.2.2",
+    "goinstant/form":"v1.1.1",
+    "goinstant/chat":"v1.0.2"
   },
 
   "development": {


### PR DESCRIPTION
Updating these to latest to get things on the demo prior to pushing the bundle to public v1.

This will be used to tag v0.1.2 with updated widget versions.
